### PR TITLE
Use Colorful color selector

### DIFF
--- a/src/components/ColorPickerCustom.js
+++ b/src/components/ColorPickerCustom.js
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { Box, Button, Popover, Paper } from '@mui/material';
+import { Circle, Colorful } from '@uiw/react-color';
+import ColorLensIcon from '@mui/icons-material/ColorLens';
+
+const PRESET_COLORS = [
+  '#FF6B6B',
+  '#4ECDC4',
+  '#45B7D1',
+  '#96CEB4',
+  '#FFEEAD',
+  '#D4A5A5',
+  '#9B9B9B',
+  '#3A3A3A',
+  '#4A90E2',
+  '#43A047',
+];
+
+export default function ColorPickerCustom({ value = '#1976d2', onChange }) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <Box>
+      <Box mb={2}>
+        <Circle
+          colors={PRESET_COLORS}
+          color={value}
+          onChange={(color) => onChange(color.hex)}
+        />
+      </Box>
+
+      <Box display="flex" alignItems="center" gap={2}>
+        <Paper
+          sx={{
+            width: 45,
+            height: 45,
+            backgroundColor: value,
+            border: '2px solid #fff',
+            boxShadow: '0 0 0 1px rgba(0,0,0,0.1)',
+            borderRadius: '50%',
+          }}
+        />
+
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={handleClick}
+          startIcon={<ColorLensIcon />}
+        >
+          Color personalizado
+        </Button>
+
+        <Popover
+          open={open}
+          anchorEl={anchorEl}
+          onClose={handleClose}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'left',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'left',
+          }}
+        >
+          <Box p={2}>
+            <Colorful
+              style={{ width: 200 }}
+              color={value}
+              disableAlpha
+              onChange={(color) => {
+                onChange(color.hex);
+                handleClose();
+              }}
+            />
+          </Box>
+        </Popover>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/GradientForm.js
+++ b/src/components/GradientForm.js
@@ -13,8 +13,7 @@ import {
   IconButton,
   Menu,
   MenuItem,
-  Slider,
-  InputAdornment,
+  Slider
 } from "@mui/material";
 import StarIcon from "@mui/icons-material/Star";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
@@ -23,6 +22,7 @@ import { messages } from "@/i18n";
 import { ColorModeContext } from "@/theme";
 import TranslateIcon from "@mui/icons-material/Translate";
 import Brightness4Icon from "@mui/icons-material/Brightness4";
+import ColorPickerCustom from "./ColorPickerCustom";
 
 function hexToRgb(hex) {
   const h = hex.replace("#", "");
@@ -190,41 +190,10 @@ export default function GradientForm({ categories }) {
               }}
             />
             <CardContent>
-              <Box
-                sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}
-              >
-                <Button
-                  variant="outlined"
-                  component="label"
-                  startIcon={
-                    <Box
-                      sx={{
-                        width: 16,
-                        height: 16,
-                        bgcolor: startColor,
-                        border: 1,
-                        borderColor: "divider",
-                      }}
-                    />
-                  }
-                >
-                  {t.startColor}
-                  <input
-                    type="color"
-                    hidden
-                    value={startColor}
-                    onChange={(e) => setStartColor(e.target.value)}
-                  />
-                </Button>
-                <TextField
-                  size="small"
-                  value={startColor.slice(1).toUpperCase()}
-                  InputProps={{
-                    readOnly: true,
-                    startAdornment: (
-                      <InputAdornment position="start">#</InputAdornment>
-                    ),
-                  }}
+              <Box sx={{ mb: 1 }}>
+                <ColorPickerCustom
+                  value={startColor}
+                  onChange={setStartColor}
                 />
               </Box>
               <Typography gutterBottom>{t.opacity}</Typography>
@@ -250,42 +219,8 @@ export default function GradientForm({ categories }) {
               }}
             />
             <CardContent>
-              <Box
-                sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}
-              >
-                <Button
-                  variant="outlined"
-                  component="label"
-                  startIcon={
-                    <Box
-                      sx={{
-                        width: 16,
-                        height: 16,
-                        bgcolor: endColor,
-                        border: 1,
-                        borderColor: "divider",
-                      }}
-                    />
-                  }
-                >
-                  {t.endColor}
-                  <input
-                    type="color"
-                    hidden
-                    value={endColor}
-                    onChange={(e) => setEndColor(e.target.value)}
-                  />
-                </Button>
-                <TextField
-                  size="small"
-                  value={endColor.slice(1).toUpperCase()}
-                  InputProps={{
-                    readOnly: true,
-                    startAdornment: (
-                      <InputAdornment position="start">#</InputAdornment>
-                    ),
-                  }}
-                />
+              <Box sx={{ mb: 1 }}>
+                <ColorPickerCustom value={endColor} onChange={setEndColor} />
               </Box>
               <Typography gutterBottom>{t.opacity}</Typography>
               <Slider


### PR DESCRIPTION
## Summary
- add a reusable `ColorPickerCustom` component
- replace color input fields in `GradientForm` with the new Colorful picker

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68862376167083209c8fc2a2c79346f8