### PR TITLE
Improve color picker workflow

### DIFF
--- a/src/components/ColorPickerCustom.js
+++ b/src/components/ColorPickerCustom.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
-import { Box, Button, Popover, Paper } from '@mui/material';
+import { Box, Popover, Paper } from '@mui/material';
 import { Circle, Colorful } from '@uiw/react-color';
-import ColorLensIcon from '@mui/icons-material/ColorLens';
 
 const PRESET_COLORS = [
   '#FF6B6B',
@@ -16,7 +15,12 @@ const PRESET_COLORS = [
   '#43A047',
 ];
 
-export default function ColorPickerCustom({ value = '#1976d2', onChange }) {
+export default function ColorPickerCustom({
+  value = '#1976d2',
+  alpha = 255,
+  onChange,
+  onAlphaChange,
+}) {
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
 
@@ -40,24 +44,17 @@ export default function ColorPickerCustom({ value = '#1976d2', onChange }) {
 
       <Box display="flex" alignItems="center" gap={2}>
         <Paper
+          onClick={handleClick}
           sx={{
-            width: 45,
-            height: 45,
+            width: 60,
+            height: 60,
             backgroundColor: value,
             border: '2px solid #fff',
             boxShadow: '0 0 0 1px rgba(0,0,0,0.1)',
             borderRadius: '50%',
+            cursor: 'pointer',
           }}
         />
-
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={handleClick}
-          startIcon={<ColorLensIcon />}
-        >
-          Color personalizado
-        </Button>
 
         <Popover
           open={open}
@@ -74,12 +71,13 @@ export default function ColorPickerCustom({ value = '#1976d2', onChange }) {
         >
           <Box p={2}>
             <Colorful
-              style={{ width: 200 }}
-              color={value}
-              disableAlpha
+              style={{ width: 220 }}
+              color={`${value}${alpha.toString(16).padStart(2, '0')}`}
               onChange={(color) => {
                 onChange(color.hex);
-                handleClose();
+                if (onAlphaChange && color.hsva) {
+                  onAlphaChange(Math.round(color.hsva.a * 255));
+                }
               }}
             />
           </Box>

--- a/src/components/GradientForm.js
+++ b/src/components/GradientForm.js
@@ -13,7 +13,6 @@ import {
   IconButton,
   Menu,
   MenuItem,
-  Slider
 } from "@mui/material";
 import StarIcon from "@mui/icons-material/Star";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
@@ -193,16 +192,11 @@ export default function GradientForm({ categories }) {
               <Box sx={{ mb: 1 }}>
                 <ColorPickerCustom
                   value={startColor}
+                  alpha={startOpacity}
                   onChange={setStartColor}
+                  onAlphaChange={setStartOpacity}
                 />
               </Box>
-              <Typography gutterBottom>{t.opacity}</Typography>
-              <Slider
-                value={startOpacity}
-                min={0}
-                max={255}
-                onChange={(e, v) => setStartOpacity(v)}
-              />
             </CardContent>
           </Card>
           <Card
@@ -220,15 +214,13 @@ export default function GradientForm({ categories }) {
             />
             <CardContent>
               <Box sx={{ mb: 1 }}>
-                <ColorPickerCustom value={endColor} onChange={setEndColor} />
+                <ColorPickerCustom
+                  value={endColor}
+                  alpha={endOpacity}
+                  onChange={setEndColor}
+                  onAlphaChange={setEndOpacity}
+                />
               </Box>
-              <Typography gutterBottom>{t.opacity}</Typography>
-              <Slider
-                value={endOpacity}
-                min={0}
-                max={255}
-                onChange={(e, v) => setEndOpacity(v)}
-              />
             </CardContent>
           </Card>
         </Box>


### PR DESCRIPTION
## Summary
- open color picker from color preview circle
- show opacity selector in color picker
- remove dedicated color button and range sliders

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688652f90d448320a120b33c81d1f5c7