### PR TITLE
Add recent color history and icon copy buttons

### DIFF
--- a/src/components/GradientForm.js
+++ b/src/components/GradientForm.js
@@ -249,16 +249,33 @@ export default function GradientForm({ categories }) {
                     />
                     <CardContent sx={{ maxHeight: 200, overflowY: "auto" }}>
                       {items.map((item) => (
-                        <Button
-                          key={item.code}
-                          fullWidth
-                          size="small"
-                          variant="outlined"
-                          sx={{ mb: 0.5 }}
-                          onClick={() => setMessage((m) => `${m} ${item.code}`)}
-                        >
-                          {item.label}
-                        </Button>
+                        <Box key={item.code} sx={{ display: "flex", mb: 0.5 }}>
+                          <Button
+                            fullWidth
+                            size="small"
+                            variant="outlined"
+                            onClick={() =>
+                              setMessage((m) => `${m} ${item.code}`)
+                            }
+                          >
+                            {item.label}
+                          </Button>
+                          <Button
+                            size="small"
+                            variant="contained"
+                            color="primary"
+                            onClick={() =>
+                              navigator.clipboard.writeText(item.code)
+                            }
+                            sx={{
+                              minWidth: 0,
+                              width: (theme) => theme.spacing(4.5),
+                              ml: 0.5,
+                            }}
+                          >
+                            <ContentCopyIcon fontSize="small" />
+                          </Button>
+                        </Box>
                       ))}
                     </CardContent>
                   </Card>


### PR DESCRIPTION
## Summary
- store recently picked colors in `ColorPickerCustom`
- show recent colors as an extra circle palette
- add buttons next to each icon to copy its code directly
- bind RGB and Alpha text fields to the current color picker values

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688778c1826c8320995ef2259e4f8f29